### PR TITLE
New sample use case specific playbooks added

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "sOCUtilities",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "fsrMinCompatibility": "7.4.0",
     "type": "solutionpack",
     "local": true,
@@ -17,16 +17,14 @@
     "publisher": "Fortinet CSE",
     "description": "SOC Utilities Solution Pack is designed around utilities to aid in the use of FortiSOAR.",
     "certified": "false",
-    "help": "https://github.com/fortinet-fortisoar/solution-pack-soc-utilities/blob/release/1.0.0/README.md",
+    "help": "https://github.com/fortinet-fortisoar/solution-pack-soc-utilities/blob/release/1.0.1/README.md",
     "category": [
         "Utilities"
     ],
     "supportInfo": null,
     "iconLarge": null,
-    "postInstallConfig": {
-        "enabled": false
-    },
-    "date": "2023-07-14T19:54:55+00:00",
+    "postInstallConfig": null,
+    "date": "2023-10-10T12:53:14+00:00",
     "contents": {
         "playbooks": [
             {

--- a/playbooks/08 - SOC Utilities/Create Alert Dataset.json
+++ b/playbooks/08 - SOC Utilities/Create Alert Dataset.json
@@ -1,0 +1,185 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Create Alert Dataset",
+    "aliasName": null,
+    "tag": null,
+    "description": "Create dataset for existing or missing alert record across tenant",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [
+        "mi_details"
+    ],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/503555f4-07bd-4d56-b732-63defb0d3e76",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/5e66f7d6-cea2-4f44-ae1a-31e5aa7fcc74",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Create DataSet of Existing Alert",
+            "description": null,
+            "arguments": {
+                "data": "{\"MI_Title\": \"{{vars.input.params['mi_details'].title}}\",\"Alert_ID\":\"{{vars.steps.Fetch_Related_Alert[0].id}}\",\"Alert_Name\":\"{{vars.steps.Fetch_Related_Alert[0].name}}\",\"Tenant_Name\":\"{{vars.steps.Fetch_Related_Alert[0].tenant.name}}\"}"
+            },
+            "status": null,
+            "top": "440",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "09dd163b-f91f-4040-95d8-8f11ca18be34"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create DataSet of Missing Alert",
+            "description": null,
+            "arguments": {
+                "data": "{\"MI_Title\": \"{{vars.input.params['mi_details'].title}}\",\"Alert_ID\":\"Alert Missing\",\"Alert_Name\":\"Alert Missing\",\"Tenant_Name\":\"Alert Missing\"}"
+            },
+            "status": null,
+            "top": "440",
+            "left": "480",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "aca3c2f3-d773-402c-a79f-9d0caa9baff5"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Fetch Related Alert",
+            "description": "Check if the alert is related to manual input",
+            "arguments": {
+                "when": "{{vars.input.params['mi_details'].record}}",
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "uuid",
+                            "value": "{{vars.input.params['mi_details'].record | basename}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "name",
+                        "id",
+                        "tenant"
+                    ]
+                },
+                "module": "alerts?$limit=30",
+                "checkboxFields": true,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "160",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "6489fb8f-c5e8-47d5-866a-a839d5465886"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Alert Exist",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/09dd163b-f91f-4040-95d8-8f11ca18be34",
+                        "condition": "{{ vars.steps.Fetch_Related_Alert | length > 0 }}",
+                        "step_name": "Create Data Set of Existing Alert"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/aca3c2f3-d773-402c-a79f-9d0caa9baff5",
+                        "step_name": "Create Data Set of Missing Alert"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "0cdce59f-19a7-43a6-bb0c-43043775e339"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "__triggerLimit": true,
+                "step_variables": {
+                    "input": {
+                        "params": []
+                    }
+                },
+                "triggerOnSource": true,
+                "triggerOnReplicate": false
+            },
+            "status": null,
+            "top": "20",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+            "group": null,
+            "uuid": "5e66f7d6-cea2-4f44-ae1a-31e5aa7fcc74"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Alert Exist -> Create DS",
+            "targetStep": "\/api\/3\/workflow_steps\/09dd163b-f91f-4040-95d8-8f11ca18be34",
+            "sourceStep": "\/api\/3\/workflow_steps\/0cdce59f-19a7-43a6-bb0c-43043775e339",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "990b3a5d-3a27-4bb4-9488-1e8315b3c8bc"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Alert Exist -> Create DS of Missing Alert",
+            "targetStep": "\/api\/3\/workflow_steps\/aca3c2f3-d773-402c-a79f-9d0caa9baff5",
+            "sourceStep": "\/api\/3\/workflow_steps\/0cdce59f-19a7-43a6-bb0c-43043775e339",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "04e4bc3d-f425-497b-8fc3-4ceef172d4ec"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Alert Exists -> Alert Exist",
+            "targetStep": "\/api\/3\/workflow_steps\/0cdce59f-19a7-43a6-bb0c-43043775e339",
+            "sourceStep": "\/api\/3\/workflow_steps\/6489fb8f-c5e8-47d5-866a-a839d5465886",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "cff47565-e8db-4c7d-a67e-be0b31aa4c6f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Check Alert Exists",
+            "targetStep": "\/api\/3\/workflow_steps\/6489fb8f-c5e8-47d5-866a-a839d5465886",
+            "sourceStep": "\/api\/3\/workflow_steps\/5e66f7d6-cea2-4f44-ae1a-31e5aa7fcc74",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "014706e4-0f1e-408c-a124-0f18d2060bfd"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "90d43540-d584-4662-9fd8-c92df5f1e7b4",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "Referenced"
+    ]
+}

--- a/playbooks/08 - SOC Utilities/Extract Related Alert of Pending Manual Input in CSV.json
+++ b/playbooks/08 - SOC Utilities/Extract Related Alert of Pending Manual Input in CSV.json
@@ -1,0 +1,222 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Extract Related Alert of Pending Manual Input in CSV",
+    "aliasName": null,
+    "tag": null,
+    "description": "Retrieve all pending manual input records for user action\/input and generates CSV attachments for related and missing alerts.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/503555f4-07bd-4d56-b732-63defb0d3e76",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/549086be-f9f3-4111-924b-e16668065743",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Combine Alerts all Data Set",
+            "description": "combine a dataset of existing or missing alerts associated with manual input.",
+            "arguments": {
+                "_temp": "{% for record in vars.steps.Create_DataSet %}\n {{vars.dataSet.append(record.data)}}\n{%endfor%}"
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "b113dd49-a4a8-416a-9436-f329833c7002"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configurations",
+            "description": "Limit: Limit for maximum awaiting manual input to fetch.\noffset: Starting index of the awaiting manual input to fetch, default is 0",
+            "arguments": {
+                "limit": "100",
+                "offset": "0"
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "d6286f73-80f5-4623-a6fd-88e3111da449"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create CSV Attachment",
+            "description": "Create Zip file of a dataset of existing or missing alerts associated with manual input.",
+            "arguments": {
+                "name": "CSV Data Management",
+                "params": {
+                    "meta": "",
+                    "input": "JSON",
+                    "json_data": "{{vars.dataSet}}",
+                    "csvFileName": "Manual-Input-Details",
+                    "record_path": ""
+                },
+                "version": "1.2.0",
+                "connector": "csv-data-management",
+                "operation": "convert_json_to_csv_file",
+                "operationTitle": "Convert JSON to CSV File",
+                "pickFromTenant": false,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "62d29b1a-b1b2-4b41-a178-864b30c86612"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create DataSet",
+            "description": "Creates a dataset of existing or missing alerts associated with manual input.",
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Fetch_Pending_Manual_Inputs.data['hydra:member']}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "arguments": {
+                    "mi_details": "{{vars.item}}"
+                },
+                "apply_async": false,
+                "step_variables": [],
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/90d43540-d584-4662-9fd8-c92df5f1e7b4"
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "89f2f5ad-afc6-4887-9625-71e12ec6aa71"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Fetch Pending Manual Inputs",
+            "description": "Retrieves a list of manual input awaiting users action.",
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/manual-wf-input\/list_wfinput\/?format=json&limit={{vars.limit}}&offset={{vars.offset}}&ordering=-id&unauthenticated_input=false",
+                    "body": "{\"assigned_to\":\"all\",\"is_approval\":false}",
+                    "method": "POST"
+                },
+                "version": "3.2.5",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "dataSet": "[]"
+                }
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "754efd62-1986-457d-96ac-50344e60a66e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "route": "f8891ad9-6efb-4f45-9a64-e8a1c01a7984",
+                "resources": [
+                    "alerts"
+                ],
+                "__triggerLimit": true,
+                "inputVariables": [],
+                "step_variables": {
+                    "input": {
+                        "params": [],
+                        "records": "{{vars.input.records}}"
+                    }
+                },
+                "_promptexpanded": true,
+                "triggerOnSource": true,
+                "executeButtonText": "Execute",
+                "noRecordExecution": true,
+                "showToasterMessage": {
+                    "visible": false,
+                    "messageVisible": true
+                },
+                "triggerOnReplicate": false,
+                "singleRecordExecution": false
+            },
+            "status": null,
+            "top": "30",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+            "group": null,
+            "uuid": "549086be-f9f3-4111-924b-e16668065743"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Call -> CombineAll",
+            "targetStep": "\/api\/3\/workflow_steps\/b113dd49-a4a8-416a-9436-f329833c7002",
+            "sourceStep": "\/api\/3\/workflow_steps\/89f2f5ad-afc6-4887-9625-71e12ec6aa71",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "1d5beaaf-9c8e-49c3-9ce0-e3221e65c76e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "CombineAll -> Create CSV",
+            "targetStep": "\/api\/3\/workflow_steps\/62d29b1a-b1b2-4b41-a178-864b30c86612",
+            "sourceStep": "\/api\/3\/workflow_steps\/b113dd49-a4a8-416a-9436-f329833c7002",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "78d58df0-5457-4c34-9ea0-77eb8e6b7d18"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configurations -> Get Pending Manual Inputs",
+            "targetStep": "\/api\/3\/workflow_steps\/754efd62-1986-457d-96ac-50344e60a66e",
+            "sourceStep": "\/api\/3\/workflow_steps\/d6286f73-80f5-4623-a6fd-88e3111da449",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f0de2ca2-d162-4e8d-b285-af96c4ea27eb"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get MI -> Call",
+            "targetStep": "\/api\/3\/workflow_steps\/89f2f5ad-afc6-4887-9625-71e12ec6aa71",
+            "sourceStep": "\/api\/3\/workflow_steps\/754efd62-1986-457d-96ac-50344e60a66e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b7b8e5a8-45d2-4692-a21d-03cb467cdd7a"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configurations",
+            "targetStep": "\/api\/3\/workflow_steps\/d6286f73-80f5-4623-a6fd-88e3111da449",
+            "sourceStep": "\/api\/3\/workflow_steps\/549086be-f9f3-4111-924b-e16668065743",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "fb420c52-4981-476f-893e-25795006933e"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "27a002ed-334c-417e-8c50-ab952ded6c7d",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "ManualTrigger"
+    ]
+}

--- a/playbooks/08 - SOC Utilities/Terminate Awaiting Data Ingestion playbooks.json
+++ b/playbooks/08 - SOC Utilities/Terminate Awaiting Data Ingestion playbooks.json
@@ -1,0 +1,335 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Terminate Awaiting Data Ingestion playbooks",
+    "aliasName": null,
+    "tag": null,
+    "description": "Terminates list of data ingestion playbooks which are stuck in awaiting state from last x minutes",
+    "isActive": true,
+    "debug": true,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/503555f4-07bd-4d56-b732-63defb0d3e76",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/a537bd79-9305-4c1c-a92d-c8d1e5fe65be",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configurations",
+            "description": "Limit: Limit for maximum awaiting data ingestion playbook to fetch.\noffset: Starting index of the awaiting data ingestion playbook to fetch, default is 0\nbatch_size: Maximum batch size to terminate the data ingestion playbooks.",
+            "arguments": {
+                "user": "{{vars.request.currentUser if vars.request.currentUser else \/api\/3\/people\/5776d19f-5319-4eff-806c-2125eeed2393}}",
+                "limit": "10000",
+                "offset": "0",
+                "batch_size": "5",
+                "last_x_minute": "{{vars.input.params.lastXMinutes}}",
+                "send_notification": "false"
+            },
+            "status": null,
+            "top": "160",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "67fce7c4-b5c0-4ae2-8d5d-3dc01d7724ad"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Convert last X minute Datetime",
+            "description": "Converting last x minutes timestamp to YYYY-MM-DD+HH:mm:ss format.",
+            "arguments": {
+                "current_time": "{{arrow.utcnow().format(\"YYYY-MM-DD+HH:mm:ss\")}}",
+                "last_timestamp": "{{arrow.utcnow().shift(minutes=-vars.last_x_minute).format(\"YYYY-MM-DD+HH:mm:ss\")}}"
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "a0f27e71-da89-4f3a-bad8-8d5628633cf8"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create DataSet",
+            "description": "Creates dataset for awaiting playbooks which are stuck in awaiting state from specified timestamp",
+            "arguments": {
+                "dataset_awaiting_paybooks": "{{vars.steps.Get_Awaiting_Playbooks_of_Manual_Input.data['hydra:member'] | json_query('[].{WFID: \"@id\",Name : name,Status : status,Awaiting_since: modified }')}}"
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "ce74c0c3-937e-454a-9b2e-2487d5dce8a6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Awaiting Playbooks of Manual Input",
+            "description": "Retrieves all data ingestion playbooks stuck in the awaiting state from the specified timestamp",
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/workflows\/log_list\/?format=json&limit={{vars.limit}}&modified_before={{vars.last_timestamp}}&offset={{vars.offset}}&ordering=-modified&page=1&parent__isnull=True&tags_exclude=system&status=awaiting&tags_include=dataingestion",
+                    "body": "",
+                    "method": "POST"
+                },
+                "version": "3.2.5",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "6525d7a2-bacd-434c-9497-e364d055e2c0"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Send Notification",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/65ff0e1c-ae72-4bb3-9cf0-7ae1a45d5c80",
+                        "condition": "{{ vars.send_notification }}",
+                        "step_name": "Send Notification"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/e212ab38-c8dc-4638-b04c-c3787ef50fff",
+                        "step_name": "Terminate Playbooks"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "02952ca1-535a-40cc-934b-28c72c5e0e1d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Send Notification",
+            "description": "Send Dataset to specified email address",
+            "arguments": {
+                "when": "{{vars.dataset_awaiting_paybooks | length > 0}}",
+                "config": "14ca52f1-89b2-450f-be79-7201ac56d058",
+                "params": {
+                    "cc": "",
+                    "to": "noreply@example.com",
+                    "bcc": "",
+                    "from": "",
+                    "type": "Manual Input",
+                    "content": "<p>&nbsp; Following are details for data ingestion playbooks which are stuck in <span style=\"background: #F5A623; color: #fff;\" class=\"badge badge-pill badge-danger\">Awaiting State<\/span><\/p>\n<p>&nbsp;<\/p>\n<p>{% for item in vars.dataset_awaiting_paybooks %}<\/p>\n<ul style=\"list-style-type: square;\">\n<li><strong>Name <\/strong> - {{ item.Name | title }} ;<strong> Current Status<\/strong> - {{item.Status | title }} ;&nbsp; <strong>Awaiting Since<\/strong>&nbsp;- {{item.Awaiting_since.replace(\"T\",\" \").split('.')[0]}}<\/li>\n<\/ul>\n<p>{% endfor %}<\/p>",
+                    "subject": "Data Ingestion Playbooks In Awaiting State",
+                    "iri_list": "",
+                    "body_type": "Rich Text",
+                    "file_name": "",
+                    "file_path": ""
+                },
+                "version": "2.5.0",
+                "from_str": "admin@example.com",
+                "connector": "smtp",
+                "operation": "send_email_new",
+                "operationTitle": "Send Email (Advanced)",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "820",
+            "left": "520",
+            "stepType": "\/api\/3\/workflow_step_types\/4c0019b2-055c-44d0-968c-678a0c2d762e",
+            "group": null,
+            "uuid": "65ff0e1c-ae72-4bb3-9cf0-7ae1a45d5c80"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "route": "55dbe4c4-313e-44c3-9c03-2bd8ad78334d",
+                "resources": [
+                    "alerts"
+                ],
+                "__triggerLimit": true,
+                "inputVariables": [
+                    {
+                        "name": "lastXMinutes",
+                        "type": "integer",
+                        "label": "Last X Minutes",
+                        "title": "Integer Field",
+                        "usable": true,
+                        "tooltip": "Specify a timestamp of the last x minutes, terminating all awaiting data ingestion playbooks before that timestamp.",
+                        "dataType": "integer",
+                        "formType": "integer",
+                        "required": true,
+                        "_expanded": true,
+                        "mmdUpdate": true,
+                        "collection": false,
+                        "searchable": true,
+                        "templateUrl": "app\/components\/form\/fields\/integer.html",
+                        "defaultValue": 30,
+                        "_previousName": "lastXMinute",
+                        "playbookField": true,
+                        "lengthConstraint": true,
+                        "allowedEncryption": false,
+                        "allowedGridColumn": true,
+                        "jinjaExpressionView": true,
+                        "useRecordFieldDefault": false
+                    }
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": {
+                            "lastXMinutes": "{{vars.request.data[\"lastXMinutes\"]}}"
+                        },
+                        "records": "{{vars.input.records}}"
+                    }
+                },
+                "_promptexpanded": true,
+                "triggerOnSource": true,
+                "executeButtonText": "Submit",
+                "noRecordExecution": true,
+                "showToasterMessage": {
+                    "visible": false,
+                    "messageVisible": true
+                },
+                "triggerOnReplicate": false,
+                "singleRecordExecution": false
+            },
+            "status": null,
+            "top": "30",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+            "group": null,
+            "uuid": "a537bd79-9305-4c1c-a92d-c8d1e5fe65be"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Terminate Playbooks",
+            "description": "Terminates all data ingestion playbooks which are stuck in awaiting state.",
+            "arguments": {
+                "when": "{{vars.dataset_awaiting_paybooks}}",
+                "params": {
+                    "iri": "\/api\/wf\/workflow\/revoke\/tasks\/?format=json",
+                    "body": "{\"wfLogId\":{{vars.item.WFID.split(\"\/\")[-2]}},\"user\":\"{{vars.user}}\"}",
+                    "method": "POST"
+                },
+                "version": "3.2.5",
+                "for_each": {
+                    "item": "{{vars.dataset_awaiting_paybooks}}",
+                    "__bulk": false,
+                    "parallel": true,
+                    "condition": ""
+                },
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "980",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "e212ab38-c8dc-4638-b04c-c3787ef50fff"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "API CALL -> Awaiting Playbook List",
+            "targetStep": "\/api\/3\/workflow_steps\/ce74c0c3-937e-454a-9b2e-2487d5dce8a6",
+            "sourceStep": "\/api\/3\/workflow_steps\/6525d7a2-bacd-434c-9497-e364d055e2c0",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "fc5666f9-d321-48ec-80b9-2295adebecaf"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> API CALL",
+            "targetStep": "\/api\/3\/workflow_steps\/6525d7a2-bacd-434c-9497-e364d055e2c0",
+            "sourceStep": "\/api\/3\/workflow_steps\/a0f27e71-da89-4f3a-bad8-8d5628633cf8",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9623c7e7-fd9c-413c-94d4-52914055e20d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configurations1 -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/a0f27e71-da89-4f3a-bad8-8d5628633cf8",
+            "sourceStep": "\/api\/3\/workflow_steps\/67fce7c4-b5c0-4ae2-8d5d-3dc01d7724ad",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d9439694-75f1-4145-a980-08a4647c33d3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Create DataSet -> Is Send Notification",
+            "targetStep": "\/api\/3\/workflow_steps\/02952ca1-535a-40cc-934b-28c72c5e0e1d",
+            "sourceStep": "\/api\/3\/workflow_steps\/ce74c0c3-937e-454a-9b2e-2487d5dce8a6",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9207a860-d9fc-422e-8466-086cfacd97bf"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Send Notification -> Send Notification",
+            "targetStep": "\/api\/3\/workflow_steps\/65ff0e1c-ae72-4bb3-9cf0-7ae1a45d5c80",
+            "sourceStep": "\/api\/3\/workflow_steps\/02952ca1-535a-40cc-934b-28c72c5e0e1d",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0789efe2-c75a-4678-842e-0fd8dd3000cf"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Send Notification -> Terminate Playbooks",
+            "targetStep": "\/api\/3\/workflow_steps\/e212ab38-c8dc-4638-b04c-c3787ef50fff",
+            "sourceStep": "\/api\/3\/workflow_steps\/02952ca1-535a-40cc-934b-28c72c5e0e1d",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "af72698f-86c9-49fe-8522-9752023afdad"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Send Notification -> Terminate Playbooks",
+            "targetStep": "\/api\/3\/workflow_steps\/e212ab38-c8dc-4638-b04c-c3787ef50fff",
+            "sourceStep": "\/api\/3\/workflow_steps\/65ff0e1c-ae72-4bb3-9cf0-7ae1a45d5c80",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2f6845aa-5b9c-4641-ad7a-239d7f9ed09c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configurations",
+            "targetStep": "\/api\/3\/workflow_steps\/67fce7c4-b5c0-4ae2-8d5d-3dc01d7724ad",
+            "sourceStep": "\/api\/3\/workflow_steps\/a537bd79-9305-4c1c-a92d-c8d1e5fe65be",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "44a4b3f4-4412-423e-b66e-e0b1aea4f0d8"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "286a9290-2abe-4767-ab43-9122ece60933",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "ManualTrigger"
+    ]
+}

--- a/playbooks/08 - SOC Utilities/Terminate Pending Manual Inputs.json
+++ b/playbooks/08 - SOC Utilities/Terminate Pending Manual Inputs.json
@@ -1,0 +1,214 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Terminate Pending Manual Inputs",
+    "aliasName": null,
+    "tag": null,
+    "description": "Terminates all manual input pending for user action\/inputs that have been created before the specified timestamp.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/503555f4-07bd-4d56-b732-63defb0d3e76",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/0a825e19-1aa0-4948-8db5-68d640f8cdbe",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configurations",
+            "description": "Limit: Limit for maximum awaiting manual input to fetch.\noffset: Starting index of the awaiting manual input to fetch, default is 0",
+            "arguments": {
+                "limit": "10000",
+                "offset": "0",
+                "delete_old_records_to_till_date": "{{vars.input.params.tillDate}}"
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "db553f46-9b9d-4473-8785-cbf171d9c43a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Filter manual input to be deleted",
+            "description": "Filtering manual input to be terminated",
+            "arguments": {
+                "manual_input_records": "{{vars.steps.Retrieves_all_Pending_Manual_Inputs.data[\"hydra:member\"] | json_query(\"[?created<='\"+vars.delete_old_records_to_till_date+\"']\")}}"
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "8d54bdd9-5f12-4f82-b68b-04e01f3990f2"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Retrieves all Pending Manual Inputs",
+            "description": "Retrieves a list of manual inputs that are awaiting user action.",
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/manual-wf-input\/list_wfinput\/?format=json&limit={{vars.limit}}&offset={{vars.offset}}&ordering=-id&unauthenticated_input=false",
+                    "body": "{\"assigned_to\":\"all\",\"is_approval\":false}",
+                    "method": "POST"
+                },
+                "version": "3.2.5",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "9e8e5d3d-7101-4424-985b-a1f575ed766b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "route": "4657d2cb-d43d-449f-b7f8-7b2f91b9e378",
+                "resources": [
+                    "alerts"
+                ],
+                "__triggerLimit": true,
+                "inputVariables": [
+                    {
+                        "name": "tillDate",
+                        "type": "integer",
+                        "label": "Till Date",
+                        "title": "Date\/Time Field",
+                        "usable": true,
+                        "tooltip": "Select the DateTime using which you want to delete manual input records that have been created before the specified timestamp.",
+                        "dataType": "datetime",
+                        "formType": "datetime",
+                        "required": true,
+                        "_expanded": true,
+                        "mmdUpdate": true,
+                        "collection": false,
+                        "searchable": true,
+                        "templateUrl": "app\/components\/form\/fields\/datetime.html",
+                        "defaultValue": null,
+                        "_previousName": "deleteRecordTillDate",
+                        "playbookField": true,
+                        "lengthConstraint": false,
+                        "allowedEncryption": false,
+                        "allowedGridColumn": true,
+                        "jinjaExpressionView": true,
+                        "useRecordFieldDefault": false
+                    }
+                ],
+                "step_variables": {
+                    "input": {
+                        "params": {
+                            "tillDate": "{{vars.request.data[\"tillDate\"]}}"
+                        },
+                        "records": "{{vars.input.records}}"
+                    }
+                },
+                "_promptexpanded": true,
+                "triggerOnSource": true,
+                "executeButtonText": "Submit",
+                "noRecordExecution": true,
+                "showToasterMessage": {
+                    "visible": false,
+                    "messageVisible": true
+                },
+                "triggerOnReplicate": false,
+                "singleRecordExecution": false
+            },
+            "status": null,
+            "top": "30",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+            "group": null,
+            "uuid": "0a825e19-1aa0-4948-8db5-68d640f8cdbe"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Terminates Manual Inputs",
+            "description": "Deleting filtered manual input",
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/manual-wf-input\/{{vars.item.id}}\/?format=json",
+                    "body": "",
+                    "method": "DELETE"
+                },
+                "version": "3.2.5",
+                "for_each": {
+                    "item": "{{vars.manual_input_records}}",
+                    "__bulk": false,
+                    "parallel": true,
+                    "condition": ""
+                },
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "4ccc0513-783e-4a04-b338-aed2bab878a0"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configurations -> Get Pending Manual Input",
+            "targetStep": "\/api\/3\/workflow_steps\/9e8e5d3d-7101-4424-985b-a1f575ed766b",
+            "sourceStep": "\/api\/3\/workflow_steps\/db553f46-9b9d-4473-8785-cbf171d9c43a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "1248ffac-ec93-4213-96e3-2b5465a9e6f4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get MI -> Get Old MI",
+            "targetStep": "\/api\/3\/workflow_steps\/8d54bdd9-5f12-4f82-b68b-04e01f3990f2",
+            "sourceStep": "\/api\/3\/workflow_steps\/9e8e5d3d-7101-4424-985b-a1f575ed766b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a7dde089-c961-4f31-9c1d-53165f77ab97"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Old Manual Input -> Delete Old Manual Input",
+            "targetStep": "\/api\/3\/workflow_steps\/4ccc0513-783e-4a04-b338-aed2bab878a0",
+            "sourceStep": "\/api\/3\/workflow_steps\/8d54bdd9-5f12-4f82-b68b-04e01f3990f2",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "09b06abd-e1d0-4826-98a1-723748b1feb5"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configurations",
+            "targetStep": "\/api\/3\/workflow_steps\/db553f46-9b9d-4473-8785-cbf171d9c43a",
+            "sourceStep": "\/api\/3\/workflow_steps\/0a825e19-1aa0-4948-8db5-68d640f8cdbe",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9bafcab1-fdb4-440c-b3a3-78248e8de6ef"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "uuid": "690c3ee3-e16d-4e82-bfd6-b21e6df7e72b",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "ManualTrigger"
+    ]
+}

--- a/playbooks/tags.json
+++ b/playbooks/tags.json
@@ -1,3 +1,4 @@
 [
-    "ManualTrigger"
+    "ManualTrigger",
+    "Referenced"
 ]

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,14 @@
+| [Home](./README.md) |
+|----------------------|
+
+# What's New
+
+| Compatible Version | FortiSOAR v7.4.0 and later |
+|--------------------|----------------------------|
+
+
+## Playbook Enhancements
+- Added new playbooks to **08 - SOC Utilities** playbook collection.
+    - **Terminate Awaiting Data Ingestion playbooks**
+    - **Extract Related Alert of Pending Manual Input in CSV**
+    - **Terminate Pending Manual Inputs**


### PR DESCRIPTION
 Added new playbooks to **08 - SOC Utilities** playbook collection.
**Extract Related Alert of Pending Manual Input in CSV**
   Retrieve all pending manual input records for user action/input and generates CSV attachments for related and missing alerts.


**Terminate Pending Manual Inputs**
Terminates all manual input pending for user action/inputs that have been created before the specified timestamp.


**Terminate Awaiting Data Ingestion playbooks**
Terminates list of data ingestion playbooks which are stuck in awaiting state from last x minutes

UTC
----
Verified playbook working flow with required input parameters


